### PR TITLE
Fix scan on comment

### DIFF
--- a/src/ble/bluetoothctl-adapter.ts
+++ b/src/ble/bluetoothctl-adapter.ts
@@ -60,7 +60,7 @@ export class BluetoothctlBleAdapter extends EventEmitter implements BLEAdapter {
           this.process.stdin.write('devices\n');
         }
       }, 800);
-      // Do send 'scan on' (even if it fails, it does not hurt0))
+      // Do send 'scan on' (even if it fails, it does not hurt)
       setTimeout(() => {
         if (this.process && this.process.stdin) {
           this.process.stdin.write('scan on\nscan.duplicate-data off\n');


### PR DESCRIPTION
## Summary
- fix typo in comment about enabling scan on when using bluetoothctl

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687dfda6f5808323baa8ee85329bd126