### PR TITLE
Fix event listener cleanup

### DIFF
--- a/src/nodered/victron-ble.ts
+++ b/src/nodered/victron-ble.ts
@@ -36,9 +36,9 @@ module.exports = function(RED: NodeAPI) {
     }
     scanner.on('parsed', onPacket);
 
-    node.on('close', function() {
-      scanner.emitter.removeListener('packet', onPacket);
-    });
+      node.on('close', function() {
+        scanner.removeListener('parsed', onPacket);
+      });
   }
 
   RED.nodes.registerType('victron-ble', VictronBleNode ,{ credentials: { key: { type: "password" }}} );


### PR DESCRIPTION
## Summary
- cleanup Node-RED node on close by removing the parsed listener from Scanner

## Testing
- `npm run build` *(fails: cannot reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_687dfda4e2248323a52c067a236bf4b3