### PR TITLE
Fix event listener cleanup in Node-RED node

### DIFF
--- a/src/nodered/victron-ble.ts
+++ b/src/nodered/victron-ble.ts
@@ -37,7 +37,7 @@ module.exports = function(RED: NodeAPI) {
     scanner.on('parsed', onPacket);
 
     node.on('close', function() {
-      scanner.emitter.removeListener('packet', onPacket);
+      scanner.removeListener('parsed', onPacket);
     });
   }
 


### PR DESCRIPTION
## Summary
- fix incorrect reference when removing event listener in Node-RED node

## Testing
- `npm run build` *(fails: Cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687dfc2a7f0c8323be5e65162ea6e3fa