### PR TITLE
Fix listener removal in Node-RED node

### DIFF
--- a/src/nodered/victron-ble.ts
+++ b/src/nodered/victron-ble.ts
@@ -37,7 +37,8 @@ module.exports = function(RED: NodeAPI) {
     scanner.on('parsed', onPacket);
 
     node.on('close', function() {
-      scanner.emitter.removeListener('packet', onPacket);
+      // unregister listener when node stops
+      scanner.removeListener('parsed', onPacket);
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure the Node-RED node removes the correct listener on shutdown

## Testing
- `npm run build` *(fails: Cannot find module 'events' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687dfc143c44832383a882c0b996e649