### PR TITLE
Update victron-ble.ts

### DIFF
--- a/src/nodered/victron-ble.ts
+++ b/src/nodered/victron-ble.ts
@@ -22,7 +22,7 @@ module.exports = function(RED: NodeAPI) {
     RED.nodes.createNode(this, config);
     const node = this;
     const address = (config.address || '').toLowerCase();
-    const key = (this.credentials as any).key;
+    const key = this.credentials.key || config.key;
     const includeRaw = config.includeRaw || false;
     const scanner = getScanner();
 


### PR DESCRIPTION
The node read encryption keys only from the credentials store, which was empty. Patched to fall back to config.key (plaintext in flows.json).