### PR TITLE
[codex] Fix noble discovery identity handling

### DIFF
--- a/src/ble/ble-adapter.ts
+++ b/src/ble/ble-adapter.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 export interface BLEDevice {
   address: string;
   name?: string;
+  rssi?: number;
 }
 
 export interface BLERawPacket extends BLEDevice {

--- a/src/ble/noble-adapter.ts
+++ b/src/ble/noble-adapter.ts
@@ -15,16 +15,18 @@ export class NobleBleAdapter extends EventEmitter implements BLEAdapter {
             this.scanning = true;
             noble.on('discover', (peripheral: Peripheral) => {
               const adv = peripheral.advertisement;
+              const address = peripheral.address || peripheral.uuid;
               const device: BLEDevice = {
-                address: peripheral.address,
+                address,
                 name: adv.localName,
+                rssi: peripheral.rssi,
               };
               this.discovered.set(device.address, device);
               if (adv.manufacturerData) {
                 const packet: BLERawPacket = {
                   ...device,
                   rssi: peripheral.rssi,
-                  rawData: adv.manufacturerData,
+                  rawData: normalizeManufacturerData(adv.manufacturerData),
                 };
                 this.emit('raw', packet);
               }
@@ -48,4 +50,11 @@ export class NobleBleAdapter extends EventEmitter implements BLEAdapter {
   getDiscoveredDevices(): BLEDevice[] {
     return Array.from(this.discovered.values());
   }
-} 
+}
+
+function normalizeManufacturerData(data: Buffer): Buffer {
+  if (data.length > 2 && data.readUInt16LE(0) === 0x02e1) {
+    return data.subarray(2);
+  }
+  return data;
+}

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -25,7 +25,6 @@ export class Scanner extends EventEmitter {
     this.ble = await getBleAdapter();
     if (!this.ble) return; 
     this.ble.on('raw', (packet: BLERawPacket) => this.handleRawPacket(packet));
-    await this.ble.startScan();
   }
 
   async stop(): Promise<void> {
@@ -39,7 +38,17 @@ export class Scanner extends EventEmitter {
   }
 
   getDiscoveredDevices(): DiscoveredDevice[] {
-    return Array.from(this.discovered.values());
+    const devices = new Map(this.discovered);
+    for (const device of this.ble?.getDiscoveredDevices() ?? []) {
+      const address = device.address.toLowerCase();
+      const existing = devices.get(address);
+      devices.set(address, {
+        address,
+        name: device.name ?? existing?.name ?? '',
+        rssi: device.rssi ?? existing?.rssi ?? 0,
+      });
+    }
+    return Array.from(devices.values());
   }
 
   private handleRawPacket(packet: BLERawPacket): void {
@@ -51,7 +60,7 @@ export class Scanner extends EventEmitter {
       dev = { address, name: packet.name || '', rssi: packet.rssi };
       this.discovered.set(address, dev);
     } else {
-      dev.name = packet.name || '';
+      dev.name = packet.name || dev.name;
       dev.rssi = packet.rssi;
     }
     // Try to parse if we have a key


### PR DESCRIPTION
## Summary

Fixes noble-based discovery on platforms where noble does not expose a BLE MAC address, such as macOS. The noble adapter now falls back to `peripheral.uuid`, keeps RSSI on discovered devices, and normalizes Victron manufacturer data when noble includes the company identifier prefix.

The scanner now merges adapter-level discovered devices into the discover output, so devices seen by noble are listed even before a raw manufacturer-data packet has been parsed.

## Validation

- `npm test`
- `npm run build`