### PR TITLE
[codex] Add BlueZ DBus BLE adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,22 +59,28 @@ This project is inspired by [keshavdv/victron-ble](https://github.com/keshavdv/v
 
 ## BLE Backend Selection
 
-This library supports two different BLE backends:
+This library supports three different BLE backends:
 
-1. **bluetoothctl terminal output parsing** (default):
-   - The library will first attempt to use a custom adapter that parses the terminal output of the `bluetoothctl` command.
-   - This approach is necessary to support Victron GX, Ekrano, and similar devices, as well as most Linux systems where noble may not function, because it need to run as root.
+1. **BlueZ via DBus** (default on Linux when available):
+   - The library first attempts to use BlueZ directly through the system DBus API.
+   - This avoids the root access requirement of noble and avoids parsing terminal output from `bluetoothctl`.
+   - It reads Victron Instant Readout advertisement data from BlueZ `Device1.ManufacturerData` updates.
+   - **Note:** This backend is only available on Linux systems with BlueZ and DBus access.
+
+2. **bluetoothctl terminal output parsing** (fallback):
+   - If the DBus backend is unavailable or fails to start, the library attempts to use a custom adapter that parses the terminal output of the `bluetoothctl` command.
+   - This approach is necessary to support Victron GX, Ekrano, and similar devices, as well as most Linux systems where noble may not function, because noble needs to run as root.
    - The adapter runs `bluetoothctl` as a subprocess, parses its output in real time, and emits BLE advertisement events.
    - **Note:** This method does not work on macOS or Windows, as `bluetoothctl` is not available there.
 
-2. **noble** (fallback):
-   - If `bluetoothctl` is not available or fails to start, the library falls back to the [noble](https://github.com/noble/noble) BLE library.
+3. **noble** (final fallback):
+   - If BlueZ DBus and `bluetoothctl` are not available or fail to start, the library falls back to the [noble](https://github.com/noble/noble) BLE library.
    - This is the standard for Node.js BLE access and works on macOS, Windows, and some Linux systems.
-   - **Important limitation:** noble requires root access to access BLE hardware. On Victron GX, Ekrano, and similar devices, Node-RED runs under a non-root user, so noble cannot be used in these environments. This is a key reason for using the bluetoothctl-based approach on these platforms.
+   - **Important limitation:** noble requires root access to access BLE hardware. On Victron GX, Ekrano, and similar devices, Node-RED runs under a non-root user, so noble cannot be used in these environments. This is a key reason for using the BlueZ DBus or `bluetoothctl` approaches on these platforms.
 
 > **Note:** We previously attempted to use the `node-ble` library, but found its performance and CPU usage unacceptable for production use, especially on embedded hardware.
 
-The backend is selected automatically at runtime. If `bluetoothctl` is not available, the library will attempt to use noble instead.
+The backend is selected automatically at runtime in this order: BlueZ DBus, `bluetoothctl`, then noble.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ After installing dependencies and building the project, you can use the CLI to s
 # Discover Victron BLE devices
 npx victron-ble discover
 
+# Discover with a specific BLE backend
+npx victron-ble discover --bluetooth noble
+
 # Read data from a device (replace ADDRESS and KEY)
 npx victron-ble read <DEVICE_ADDRESS> <ENCRYPTION_KEY>
 ```
@@ -80,7 +83,8 @@ This library supports three different BLE backends:
 
 > **Note:** We previously attempted to use the `node-ble` library, but found its performance and CPU usage unacceptable for production use, especially on embedded hardware.
 
-The backend is selected automatically at runtime in this order: BlueZ DBus, `bluetoothctl`, then noble.
+The CLI selects the backend automatically by default in this order: BlueZ DBus, `bluetoothctl`, then noble.
+Use `--bluetooth auto`, `--bluetooth bluez`, `--bluetooth bluetoothctl`, or `--bluetooth noble` with `discover` or `read` to choose a backend explicitly.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@abandonware/noble": "1.9.2-26",
         "commander": "12.1.0",
+        "dbus-next": "^0.10.2",
         "reflect-metadata": "0.2.2"
       },
       "bin": {
@@ -1481,6 +1482,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@nornagon/put": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@nornagon/put/-/put-0.0.8.tgz",
+      "integrity": "sha512-ugvXJjwF5ldtUpa7D95kruNJ41yFQDEKyF5CW4TgKJnh+W/zmlBzXXeKTyqIgwMFrkePN2JqOBqcF0M0oOunow==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": ">=0.3.0"
+      }
+    },
     "node_modules/@npmcli/agent": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
@@ -2241,7 +2251,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2338,6 +2348,50 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2471,6 +2525,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -2651,6 +2725,13 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2747,6 +2828,16 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -2784,6 +2875,19 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -2813,6 +2917,13 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -2849,6 +2960,37 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/dbus-next": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/dbus-next/-/dbus-next-0.10.2.tgz",
+      "integrity": "sha512-kLNQoadPstLgKKGIXKrnRsMgtAK/o+ix3ZmcfTfvBHzghiO9yHXpoKImGnB50EXwnfSFaSAullW/7UrSkAISSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nornagon/put": "0.0.8",
+        "event-stream": "3.3.4",
+        "hexy": "^0.2.10",
+        "jsbi": "^2.0.5",
+        "long": "^4.0.0",
+        "safe-buffer": "^5.1.1",
+        "xml2js": "^0.4.17"
+      },
+      "optionalDependencies": {
+        "usocket": "^0.3.0"
       }
     },
     "node_modules/debug": {
@@ -2900,6 +3042,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -2937,10 +3089,34 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "license": "MIT"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ecc-jsbn/node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "license": "MIT",
       "optional": true
     },
@@ -3260,6 +3436,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3317,11 +3508,28 @@
       "license": "Apache-2.0",
       "optional": true
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3358,7 +3566,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -3400,6 +3608,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3481,6 +3696,37 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "license": "MIT"
     },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
@@ -3592,6 +3838,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3678,6 +3934,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3706,6 +3987,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexy": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.2.11.tgz",
+      "integrity": "sha512-ciq6hFsSG/Bpt2DmrZJtv+56zpPdnq+NQ4ijEFrveKN0ZG1mhl/LdT1NQZ9se6ty1fACcI4d4vYqC9v8EYpH2A==",
+      "license": "MIT",
+      "bin": {
+        "hexy": "bin/hexy_cmd.js"
       }
     },
     "node_modules/html-escaper": {
@@ -3744,6 +4034,22 @@
       "optional": true,
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -3979,12 +4285,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4692,6 +5019,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-2.0.5.tgz",
+      "integrity": "sha512-TzO/62Hxeb26QMb4IGlI/5X+QLr9Uqp1FPkwp2+KOICW+Q+vSuFj61c8pkT6wAns4WcK56X7CmSHhJeDGWOqxQ=="
+    },
     "node_modules/jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
@@ -4726,11 +5058,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "optional": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -4739,6 +5078,13 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4761,6 +5107,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -4844,6 +5206,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4921,6 +5289,11 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4950,6 +5323,29 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -5407,6 +5803,26 @@
         "set-blocking": "^2.0.0"
       }
     },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5619,6 +6035,25 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5766,6 +6201,13 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -5794,11 +6236,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5820,6 +6275,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
+      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5869,6 +6334,39 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -6024,8 +6522,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6033,6 +6530,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -6173,11 +6679,56 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sshpk/node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ssri": {
@@ -6214,6 +6765,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1"
       }
     },
     "node_modules/string_decoder": {
@@ -6457,6 +7017,12 @@
         "node": "*"
       }
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6475,6 +7041,20 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tr46": {
@@ -6540,6 +7120,26 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6659,7 +7259,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -6681,12 +7281,196 @@
         "node": ">=12.22.0 <13.0 || >=14.17.0"
       }
     },
+    "node_modules/usocket": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/usocket/-/usocket-0.3.0.tgz",
+      "integrity": "sha512-V/H02RNiaOCJZuPoKont/y12VJaImC6C5xW7OzPFjYu9qnig0yv9hyp9E7Wqjm6d8yZuZouH3NAfDATVMgh2SQ==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.14.2",
+        "node-gyp": "^7.1.2"
+      }
+    },
+    "node_modules/usocket/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/usocket/node_modules/aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/usocket/node_modules/are-we-there-yet": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/usocket/node_modules/gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/usocket/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/usocket/node_modules/node-gyp": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
+      "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.3",
+        "nopt": "^5.0.0",
+        "npmlog": "^4.1.2",
+        "request": "^2.88.2",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.2",
+        "tar": "^6.0.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/usocket/node_modules/npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/usocket/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/usocket/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/usocket/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/usocket/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/usocket/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -6701,6 +7485,21 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/walker": {
@@ -6823,6 +7622,28 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@abandonware/noble": "1.9.2-26",
     "commander": "12.1.0",
+    "dbus-next": "^0.10.2",
     "reflect-metadata": "0.2.2"
   },
   "devDependencies": {

--- a/src/ble/dbus-adapter.ts
+++ b/src/ble/dbus-adapter.ts
@@ -1,0 +1,291 @@
+import { EventEmitter } from 'events';
+import { createRequire } from 'module';
+import { BLEAdapter, BLEDevice, BLERawPacket } from './ble-adapter';
+
+interface BLEDeviceWithRssi extends BLEDevice {
+  rssi?: number;
+}
+
+type BluezObjects = Record<string, Record<string, Record<string, unknown>>>;
+type BluezVariantConstructor = new (signature: string, value: unknown) => unknown;
+
+interface BluezBus {
+  getProxyObject(service: string, path: string): Promise<{ getInterface(name: string): unknown }>;
+  disconnect(): void;
+}
+
+interface BluezObjectManager {
+  GetManagedObjects(): Promise<BluezObjects>;
+  on(event: 'InterfacesAdded', listener: (path: string, interfaces: Record<string, Record<string, unknown>>) => void): void;
+  removeListener(event: 'InterfacesAdded', listener: (path: string, interfaces: Record<string, Record<string, unknown>>) => void): void;
+}
+
+interface BluezAdapter {
+  StartDiscovery(): Promise<void>;
+  StopDiscovery(): Promise<void>;
+  SetDiscoveryFilter(filter: Record<string, unknown>): Promise<void>;
+}
+
+interface BluezProperties {
+  on(event: 'PropertiesChanged', listener: (interfaceName: string, changed: Record<string, unknown>, invalidated: string[]) => void): void;
+  removeListener(event: 'PropertiesChanged', listener: (interfaceName: string, changed: Record<string, unknown>, invalidated: string[]) => void): void;
+}
+
+interface DbusNext {
+  systemBus: () => BluezBus;
+  Variant: BluezVariantConstructor;
+}
+
+interface DeviceWatcher {
+  properties: BluezProperties;
+  listener: (interfaceName: string, changed: Record<string, unknown>, invalidated: string[]) => void;
+}
+
+interface ManufacturerPayload {
+  companyId: string;
+  data: Buffer;
+}
+
+const requireOptional = createRequire(__filename);
+const BLUEZ_SERVICE = 'org.bluez';
+const DBUS_OBJECT_MANAGER = 'org.freedesktop.DBus.ObjectManager';
+const DBUS_PROPERTIES = 'org.freedesktop.DBus.Properties';
+const BLUEZ_ADAPTER = 'org.bluez.Adapter1';
+const BLUEZ_DEVICE = 'org.bluez.Device1';
+const DISCOVERY_POLL_MS = 500;
+
+export class DbusBleAdapter extends EventEmitter implements BLEAdapter {
+  private scanning = false;
+  private bus: BluezBus | null = null;
+  private adapter: BluezAdapter | null = null;
+  private objectManager: BluezObjectManager | null = null;
+  private pollTimer: NodeJS.Timeout | null = null;
+  private polling = false;
+  private discovered: Map<string, BLEDeviceWithRssi> = new Map();
+  private pathAddresses: Map<string, string> = new Map();
+  private deviceWatchers: Map<string, DeviceWatcher> = new Map();
+  private lastManufacturerData: Map<string, string> = new Map();
+
+  private readonly onInterfacesAdded = (path: string, interfaces: Record<string, Record<string, unknown>>) => {
+    this.processInterfaces(path, interfaces);
+  };
+
+  async startScan(): Promise<void> {
+    if (this.scanning) return;
+    if (process.platform !== 'linux') throw new Error('BlueZ DBus adapter is only available on Linux.');
+
+    const { systemBus, Variant } = loadDbusNext();
+    this.bus = systemBus();
+
+    try {
+      const { objectManager, adapter } = await openBluezAdapter(this.bus);
+      this.objectManager = objectManager;
+      this.adapter = adapter;
+      this.objectManager.on('InterfacesAdded', this.onInterfacesAdded);
+
+      await setBluezDiscoveryFilter(adapter, Variant);
+      await adapter.StartDiscovery();
+      this.scanning = true;
+
+      await this.pollManagedObjects();
+      this.pollTimer = setInterval(() => {
+        void this.pollManagedObjects();
+      }, DISCOVERY_POLL_MS);
+    } catch (error) {
+      await this.stopScan();
+      throw error;
+    }
+  }
+
+  async stopScan(): Promise<void> {
+    this.scanning = false;
+
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+
+    if (this.objectManager) {
+      this.objectManager.removeListener('InterfacesAdded', this.onInterfacesAdded);
+      this.objectManager = null;
+    }
+
+    for (const { properties, listener } of this.deviceWatchers.values()) {
+      properties.removeListener('PropertiesChanged', listener);
+    }
+    this.deviceWatchers.clear();
+
+    if (this.adapter) {
+      await this.adapter.StopDiscovery().catch((error: unknown) => {
+        console.debug(`Warning: could not stop BlueZ discovery: ${errorMessage(error)}`);
+      });
+      this.adapter = null;
+    }
+
+    if (this.bus) {
+      this.bus.disconnect();
+      this.bus = null;
+    }
+  }
+
+  getDiscoveredDevices(): BLEDevice[] {
+    return Array.from(this.discovered.values());
+  }
+
+  private async pollManagedObjects(): Promise<void> {
+    if (!this.objectManager || this.polling) return;
+    this.polling = true;
+    try {
+      const objects = await this.objectManager.GetManagedObjects();
+      for (const [path, interfaces] of Object.entries(objects)) {
+        this.processInterfaces(path, interfaces);
+      }
+    } catch (error) {
+      console.debug(`Warning: could not poll BlueZ managed objects: ${errorMessage(error)}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  private processInterfaces(path: string, interfaces: Record<string, Record<string, unknown>>): void {
+    const device = interfaces[BLUEZ_DEVICE];
+    if (!device) return;
+
+    void this.watchDeviceProperties(path);
+    this.processDeviceProperties(path, device);
+  }
+
+  private async watchDeviceProperties(path: string): Promise<void> {
+    if (!this.bus || this.deviceWatchers.has(path)) return;
+
+    try {
+      const object = await this.bus.getProxyObject(BLUEZ_SERVICE, path);
+      const properties = object.getInterface(DBUS_PROPERTIES) as BluezProperties;
+      const listener = (interfaceName: string, changed: Record<string, unknown>) => {
+        if (interfaceName === BLUEZ_DEVICE) this.processDeviceProperties(path, changed);
+      };
+      properties.on('PropertiesChanged', listener);
+      this.deviceWatchers.set(path, { properties, listener });
+    } catch (error) {
+      console.debug(`Warning: could not watch BlueZ properties for ${path}: ${errorMessage(error)}`);
+    }
+  }
+
+  private processDeviceProperties(path: string, properties: Record<string, unknown>): void {
+    const propertyAddress = nullableString(unboxBluezValue(properties.Address));
+    const address = (propertyAddress || this.pathAddresses.get(path))?.toLowerCase();
+    if (!address) return;
+
+    this.pathAddresses.set(path, address);
+
+    const existing = this.discovered.get(address) || { address };
+    const name = nullableString(unboxBluezValue(properties.Name)) || nullableString(unboxBluezValue(properties.Alias));
+    const rssi = nullableNumber(unboxBluezValue(properties.RSSI));
+    const device: BLEDeviceWithRssi = { ...existing, address };
+
+    if (name) device.name = name;
+    if (typeof rssi === 'number') device.rssi = rssi;
+    this.discovered.set(address, device);
+
+    const manufacturerData = readManufacturerData(properties.ManufacturerData);
+    for (const payload of manufacturerData) {
+      this.emitManufacturerData(path, device, payload);
+    }
+  }
+
+  private emitManufacturerData(path: string, device: BLEDeviceWithRssi, payload: ManufacturerPayload): void {
+    if (this.listenerCount('raw') === 0) return;
+
+    const hex = payload.data.toString('hex');
+    const key = `${path}:${payload.companyId}`;
+    if (this.lastManufacturerData.get(key) === hex) return;
+    this.lastManufacturerData.set(key, hex);
+
+    const packet: BLERawPacket = {
+      ...device,
+      rssi: device.rssi ?? 0,
+      rawData: payload.data,
+    };
+    this.emit('raw', packet);
+  }
+}
+
+async function openBluezAdapter(bus: BluezBus): Promise<{ objectManager: BluezObjectManager; adapter: BluezAdapter }> {
+  const objectManagerObject = await bus.getProxyObject(BLUEZ_SERVICE, '/');
+  const objectManager = objectManagerObject.getInterface(DBUS_OBJECT_MANAGER) as BluezObjectManager;
+  const objects = await objectManager.GetManagedObjects();
+  const adapterPath = findBluezAdapterPath(objects);
+  if (!adapterPath) throw new Error('Could not find a BlueZ adapter via org.bluez ObjectManager.');
+
+  const adapterObject = await bus.getProxyObject(BLUEZ_SERVICE, adapterPath);
+  const adapter = adapterObject.getInterface(BLUEZ_ADAPTER) as BluezAdapter;
+  return { objectManager, adapter };
+}
+
+async function setBluezDiscoveryFilter(adapter: BluezAdapter, Variant: BluezVariantConstructor): Promise<void> {
+  const filter = {
+    Transport: new Variant('s', 'le'),
+    DuplicateData: new Variant('b', true),
+  };
+
+  await adapter.SetDiscoveryFilter(filter).catch((error: unknown) => {
+    console.debug(`Warning: could not set BlueZ discovery filter: ${errorMessage(error)}`);
+  });
+}
+
+function findBluezAdapterPath(objects: BluezObjects): string | null {
+  for (const [path, interfaces] of Object.entries(objects)) {
+    if (interfaces[BLUEZ_ADAPTER]) return path;
+  }
+  return null;
+}
+
+function readManufacturerData(value: unknown): ManufacturerPayload[] {
+  const data = unboxBluezValue(value);
+  if (!data || typeof data !== 'object') return [];
+
+  const entries = data instanceof Map ? Array.from(data.entries()) : Object.entries(data as Record<string, unknown>);
+  const payloads: ManufacturerPayload[] = [];
+
+  for (const [companyId, bytes] of entries) {
+    const buffer = bytesToBuffer(bytes);
+    if (buffer && buffer.length > 0) {
+      payloads.push({ companyId: String(companyId), data: buffer });
+    }
+  }
+
+  return payloads;
+}
+
+function bytesToBuffer(value: unknown): Buffer | null {
+  const unboxed = unboxBluezValue(value);
+  if (Buffer.isBuffer(unboxed)) return unboxed;
+  if (unboxed instanceof Uint8Array) return Buffer.from(unboxed);
+  if (Array.isArray(unboxed) && unboxed.every((byte) => typeof byte === 'number')) return Buffer.from(unboxed);
+  return null;
+}
+
+function nullableString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function nullableNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function unboxBluezValue(value: unknown): unknown {
+  if (value && typeof value === 'object' && 'value' in value) return (value as { value: unknown }).value;
+  return value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function loadDbusNext(): DbusNext {
+  try {
+    return requireOptional('dbus-next') as DbusNext;
+  } catch (error) {
+    throw new Error(`BlueZ DBus adapter requires the "dbus-next" dependency. ${errorMessage(error)}`);
+  }
+}

--- a/src/ble/get-ble-adapter.ts
+++ b/src/ble/get-ble-adapter.ts
@@ -3,12 +3,16 @@ import { NobleBleAdapter } from './noble-adapter';
 import { BluetoothctlBleAdapter } from './bluetoothctl-adapter';
 import { DbusBleAdapter } from './dbus-adapter';
 
-export async function getBleAdapter(): Promise<BLEAdapter> {
-  const adapters: Array<{ name: string; create: () => BLEAdapter }> = [
-    { name: 'BlueZ DBus', create: () => new DbusBleAdapter() },
-    { name: 'bluetoothctl', create: () => new BluetoothctlBleAdapter() },
-    { name: 'noble', create: () => new NobleBleAdapter() },
-  ];
+export type BleAdapterMode = 'auto' | 'bluez' | 'bluetoothctl' | 'noble';
+
+const ADAPTERS: Array<{ mode: Exclude<BleAdapterMode, 'auto'>; name: string; create: () => BLEAdapter }> = [
+  { mode: 'bluez', name: 'BlueZ DBus', create: () => new DbusBleAdapter() },
+  { mode: 'bluetoothctl', name: 'bluetoothctl', create: () => new BluetoothctlBleAdapter() },
+  { mode: 'noble', name: 'noble', create: () => new NobleBleAdapter() },
+];
+
+export async function getBleAdapter(mode: BleAdapterMode = 'auto'): Promise<BLEAdapter> {
+  const adapters = mode === 'auto' ? ADAPTERS : ADAPTERS.filter((adapter) => adapter.mode === mode);
   const errors: string[] = [];
 
   for (const { name, create } of adapters) {

--- a/src/ble/get-ble-adapter.ts
+++ b/src/ble/get-ble-adapter.ts
@@ -1,18 +1,28 @@
 import { BLEAdapter } from './ble-adapter';
 import { NobleBleAdapter } from './noble-adapter';
 import { BluetoothctlBleAdapter } from './bluetoothctl-adapter';
+import { DbusBleAdapter } from './dbus-adapter';
 
 export async function getBleAdapter(): Promise<BLEAdapter> {
-  let btctlAdapter: BluetoothctlBleAdapter | undefined = undefined;
-  try {
-    btctlAdapter = new BluetoothctlBleAdapter();
-    await btctlAdapter.startScan();
-    return btctlAdapter;
-  } catch (err: any) {
-    // Fallback to noble-based adapter
-    console.log("Try noble-based adapter");
-    const nobleAdapter = new NobleBleAdapter();
-    await nobleAdapter.startScan();
-    return nobleAdapter;
+  const adapters: Array<{ name: string; create: () => BLEAdapter }> = [
+    { name: 'BlueZ DBus', create: () => new DbusBleAdapter() },
+    { name: 'bluetoothctl', create: () => new BluetoothctlBleAdapter() },
+    { name: 'noble', create: () => new NobleBleAdapter() },
+  ];
+  const errors: string[] = [];
+
+  for (const { name, create } of adapters) {
+    const adapter = create();
+    try {
+      await adapter.startScan();
+      console.debug(`Using ${name} BLE adapter.`);
+      return adapter;
+    } catch (error) {
+      errors.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
+      await adapter.stopScan().catch(() => {});
+      console.debug(`${name} BLE adapter unavailable: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
-} 
+
+  throw new Error(`No BLE adapter available. Tried ${errors.join('; ')}`);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,20 +1,21 @@
 #!/usr/bin/env node
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
+import { BleAdapterMode } from './ble/get-ble-adapter';
 import { DiscoveredDevice, Scanner } from './scanner';
 
 // Singleton scanner instance
 let scanner: Scanner | null = null;
-function getScanner(): Scanner {
+async function getScanner(adapterMode: BleAdapterMode): Promise<Scanner> {
   if (!scanner) {
-    scanner = new Scanner();
-    scanner.start();
+    scanner = new Scanner(adapterMode);
+    await scanner.start();
   }
   return scanner;
 }
 
-async function discoverDevices(): Promise<void> {
-  const scanner = getScanner();
+async function discoverDevices(adapterMode: BleAdapterMode): Promise<void> {
+  const scanner = await getScanner(adapterMode);
   console.log('Discovering devices. Press Ctrl+C to stop.');
   process.on('SIGINT', () => {
     scanner.stop();
@@ -37,8 +38,8 @@ async function discoverDevices(): Promise<void> {
   }, 1000);
 }
 
-async function readDeviceData(address: string, key: string): Promise<void> {
-  const scanner = getScanner();
+async function readDeviceData(address: string, key: string, adapterMode: BleAdapterMode): Promise<void> {
+  const scanner = await getScanner(adapterMode);
   scanner.setSettings(address, key, true);
   console.log(`Reading data for ${address}. Press Ctrl+C to stop.`);
   scanner.on('parsed', (data) => {
@@ -54,6 +55,9 @@ async function readDeviceData(address: string, key: string): Promise<void> {
 }
 
 const program = new Command();
+const adapterModes: BleAdapterMode[] = ['auto', 'bluez', 'bluetoothctl', 'noble'];
+const bluetoothOption = () =>
+  new Option('--bluetooth <backend>', 'Bluetooth backend').choices(adapterModes).default('auto');
 
 program
   .name('victron-ble')
@@ -74,8 +78,9 @@ program
 program
   .command('discover')
   .description('Discover Victron devices with Instant Readout')
-  .action(async () => {
-    await discoverDevices();
+  .addOption(bluetoothOption())
+  .action(async (options: { bluetooth: BleAdapterMode }) => {
+    await discoverDevices(options.bluetooth);
   });
 
 program
@@ -83,8 +88,9 @@ program
   .description('Read data from a specified device')
   .argument('<address>', 'Device address')
   .argument('<key>', 'Decryption key')
-  .action(async (address: string, key: string) => {
-    await readDeviceData(address, key);
+  .addOption(bluetoothOption())
+  .action(async (address: string, key: string, options: { bluetooth: BleAdapterMode }) => {
+    await readDeviceData(address, key, options.bluetooth);
   });
 
 program.parse(); 

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -1,5 +1,5 @@
 import { BLEAdapter, BLEDevice, BLERawPacket, BLEParsedPacket } from './ble/ble-adapter';
-import { getBleAdapter } from './ble/get-ble-adapter';
+import { BleAdapterMode, getBleAdapter } from './ble/get-ble-adapter';
 import { Device } from './devices/base';
 import { detectDeviceType } from './devices';
 import { EventEmitter } from 'events';
@@ -17,12 +17,12 @@ export class Scanner extends EventEmitter {
   private knownDevices: Record<string, Device> = {};
   private discovered: Map<string, DiscoveredDevice> = new Map();
 
-  constructor() {
+  constructor(private readonly adapterMode: BleAdapterMode = 'auto') {
     super();
   }
 
   async start(): Promise<void> {
-    this.ble = await getBleAdapter();
+    this.ble = await getBleAdapter(this.adapterMode);
     if (!this.ble) return; 
     this.ble.on('raw', (packet: BLERawPacket) => this.handleRawPacket(packet));
   }


### PR DESCRIPTION
## Summary

Adds a BlueZ DBus BLE backend for Linux systems. The new adapter reads `org.bluez.Device1` manufacturer data through DBus, watches device property changes, polls managed objects during discovery, and emits raw BLE packets for scanner parsing.

Backend selection now tries BlueZ DBus first, then falls back to `bluetoothctl`, and finally noble. The PR also adds the `dbus-next` dependency and updates the README backend documentation.

## Validation

- `npm test`
- `npm run build`