### PR TITLE
Add SolarSense 750 support (Model ID 0xC050)

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -10,6 +10,7 @@ import { OrionXS } from './orion-xs';
 import { SmartBatteryProtect, OutputState } from './smart-battery-protect';
 import { SmartLithium, BalancerStatus } from './smart-lithium';
 import { SolarCharger } from './solar-charger';
+import { SolarSense } from './solar-sense';
 import { VEBus } from './vebus';
 import { getProductName } from './product-mapping';
 
@@ -43,6 +44,8 @@ export {
   LynxSmartBMS,
   // Solar Charger
   SolarCharger,
+  // Solar Sense
+  SolarSense,
   // VE.Bus
   VEBus,
 };
@@ -52,6 +55,7 @@ export {
 const MODEL_PARSER_OVERRIDE: Record<number, new (advertisementKey: string) => Device> = {
   0xA3A4: BatterySense,  // Smart Battery Sense
   0xA3A5: BatterySense,  // Smart Battery Sense
+  0xC050: SolarSense,    // SolarSense 750
 };
 
 export function detectDeviceType(data: Buffer): (new (advertisementKey: string) => Device) | null {

--- a/src/devices/products.txt
+++ b/src/devices/products.txt
@@ -765,6 +765,7 @@
 49205 SmartShunt IP65 500A/50mV
 49206 SmartShunt IP65 1000A/50mV
 49207 SmartShunt IP65 2000A/50mV
+49232 SolarSense 750
 57344 Generic example 0
 57345 Generic example 1
 57346 Generic example 2

--- a/src/devices/solar-sense.ts
+++ b/src/devices/solar-sense.ts
@@ -1,0 +1,51 @@
+import { BitReader, ChargerError, Device, EnumField } from './base';
+
+export class SolarSense extends Device {
+  errorCode?: number;
+  @EnumField(ChargerError)
+  chargerError?: ChargerError;
+  installationPower?: number;
+  todaysYield?: number;
+  irradiance?: number;
+  cellTemperature?: number;
+  batteryVoltage?: number;
+  timeSinceLastSun?: number;
+
+  // SolarSense transmits plaintext — no AES-CTR encryption
+  parse(data: Buffer): this {
+    this.modelId = this.getModelId(data);
+    this.decryptedData = data.slice(8);
+    this.parseDecrypted(this.decryptedData);
+    return this;
+  }
+
+  parseDecrypted(decrypted: Buffer): void {
+    const reader = new BitReader(decrypted);
+    const error_code = reader.readUnsignedInt(32);
+    const charger_error = reader.readUnsignedInt(8);
+    const installation_power = reader.readUnsignedInt(20);
+    const todays_yield = reader.readUnsignedInt(20);
+    const irradiance = reader.readUnsignedInt(14);
+    const cell_temperature = reader.readUnsignedInt(11);
+    reader.readUnsignedInt(1);
+    const battery_voltage = reader.readUnsignedInt(8);
+    reader.readUnsignedInt(1); // txPowerLevel
+    const time_since_last_sun = reader.readUnsignedInt(7);
+
+    this.errorCode = error_code;
+    this.chargerError = charger_error !== 0xFF ? charger_error as ChargerError : undefined;
+    this.installationPower = installation_power !== 0xFFFFF ? installation_power : undefined;
+    this.todaysYield = todays_yield !== 0xFFFFF ? todays_yield * 10 : undefined;
+    this.irradiance = irradiance !== 0x3FFF ? irradiance / 10 : undefined;
+    this.cellTemperature = cell_temperature !== 0x7FF ? cell_temperature / 10 - 60 : undefined;
+    this.batteryVoltage = battery_voltage !== 0xFF ? battery_voltage / 100 + 1.7 : undefined;
+    this.timeSinceLastSun = SolarSense.decodeTimeSinceLastSun(time_since_last_sun);
+  }
+
+  private static decodeTimeSinceLastSun(raw: number): number | undefined {
+    if (raw === 0x7F) return undefined;
+    if (raw < 30) return raw * 2;
+    if (raw < 96) return 60 + 10 * (raw - 30);
+    return 720 + 30 * (raw - 96);
+  }
+}

--- a/tests/data/solar-sense.json
+++ b/tests/data/solar-sense.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "basic parse with all fields",
+    "decryptedData": "0000000000ee02e0150034a106092a00",
+    "payload": {
+      "errorCode": 0,
+      "chargerError": 0,
+      "installationPower": 750,
+      "todaysYield": 3500,
+      "irradiance": 850.0,
+      "cellTemperature": 45.0,
+      "batteryVoltage": 3.0,
+      "timeSinceLastSun": 10
+    }
+  },
+  {
+    "name": "all optional fields N/A",
+    "decryptedData": "00000000fffffffffffffffffffdff03",
+    "payload": {
+      "errorCode": 0,
+      "chargerError": null,
+      "installationPower": null,
+      "todaysYield": null,
+      "irradiance": null,
+      "cellTemperature": null,
+      "batteryVoltage": null,
+      "timeSinceLastSun": null
+    }
+  },
+  {
+    "name": "tiered time encoding",
+    "decryptedData": "0000000000e8034006008893d4589201",
+    "payload": {
+      "errorCode": 0,
+      "chargerError": 0,
+      "installationPower": 1000,
+      "todaysYield": 1000,
+      "irradiance": 500.0,
+      "cellTemperature": 25.0,
+      "batteryVoltage": 3.2,
+      "timeSinceLastSun": 260
+    }
+  }
+]


### PR DESCRIPTION
This PR adds support for Victron Solar Sense 750. 

Solar Sense does not require encryption key as it sends the data unencrypted, but in NR you still need to specify a key for the node to get configured properly.

Values reported/decoded are matching what's visible in Victron Connect.

<img width="357" height="264" alt="Screenshot 2026-06-03 at 16 09 49" src="https://github.com/user-attachments/assets/e8c62e70-0b7c-4a3c-a35d-6b3631a3e2b4" />

<img width="295" height="639" alt="IMG_0432" src="https://github.com/user-attachments/assets/8777bf53-ba8f-4ac2-a87f-bcf6439f7272" />
