### PR TITLE
[codex] Restore Node 20 compatible commander

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@abandonware/noble": "1.9.2-26",
-        "commander": "15.0.0",
+        "commander": "^14.0.3",
         "dbus-next": "^0.10.2",
         "reflect-metadata": "0.2.2"
       },
@@ -1348,12 +1348,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/concat-map": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@abandonware/noble": "1.9.2-26",
-    "commander": "15.0.0",
+    "commander": "^14.0.3",
     "dbus-next": "^0.10.2",
     "reflect-metadata": "0.2.2"
   },


### PR DESCRIPTION
## What changed

- Downgraded `commander` from `15.0.0` to `^14.0.3`.
- Updated `package-lock.json` to lock `commander@14.0.3`, whose engine requirement is `node >=20`.

## Why

Issue #44 reports palette update failures on Venus OS v3.73 because Node-RED installs with `--engine-strict` on Node `v20.20.2`. `commander@15.0.0` now requires Node `>=22.12.0`, so npm rejects the package before installation completes.

This mirrors the fix already applied in the related BLE scanner package.

Fixes #44.

## Validation

- `npm install --package-lock-only --ignore-scripts --cache /private/tmp/npm-cache`
- `npm test`